### PR TITLE
Change the address of the VOTE function to the sender

### DIFF
--- a/contracts/L2VotingOnChainRequest.sol
+++ b/contracts/L2VotingOnChainRequest.sol
@@ -48,7 +48,8 @@ contract L2VotingOnChainRequest {
         snapshotBlock = _snapshotBlock;
     }
 
-    function vote(uint256 productId, address holder) external {
+    function vote(uint256 productId) external {
+        address holder = msg.sender;
         if (addrToVote[holder] != 0) {
             revert("Cannot vote twice");
         }


### PR DESCRIPTION
# What
Change the address of the VOTE function to the sender

# Why
Because we want to make sure that a third party cannot execute it.